### PR TITLE
correction to type of file entities, also fix segment id one of in en…

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -2024,10 +2024,6 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "segment_id": {
-                      "type": "string",
-                      "description": "Unique identifier for the segment"
-                    },
                     "start_time": {
                       "type": "number",
                       "description": "Start time of the segment in seconds"
@@ -2652,10 +2648,6 @@
             "items": {
               "type": "object",
               "properties": {
-                "segment_id": {
-                  "type": "string",
-                  "description": "Unique identifier for the segment"
-                },
                 "start_time": {
                   "type": "number",
                   "description": "Start time of the segment in seconds"

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -2025,16 +2025,7 @@
                   "type": "object",
                   "properties": {
                     "segment_id": {
-                      "oneOf": [
-                        {
-                          "type": "string",
-                          "description": "Unique identifier for the segment as a string"
-                        },
-                        {
-                          "type": "number",
-                          "description": "Unique identifier for the segment as a number"
-                        }
-                      ],
+                      "type": "string",
                       "description": "Unique identifier for the segment"
                     },
                     "start_time": {
@@ -2652,16 +2643,7 @@
             "description": "ID of the file"
           },
           "entities": {
-            "oneOf": [
-              {
-                "type": "object",
-                "description": "Map of entity type to array of entities"
-              },
-              {
-                "type": "array",
-                "description": "List of entities "
-              }
-            ],
+            "type": "object",
             "description": "Entities extracted from the file at the video level"
           },
           "segment_entities": {
@@ -2671,16 +2653,7 @@
               "type": "object",
               "properties": {
                 "segment_id": {
-                  "oneOf": [
-                    {
-                      "type": "string",
-                      "description": "Unique identifier for the segment as a string"
-                    },
-                    {
-                      "type": "number",
-                      "description": "Unique identifier for the segment as a number"
-                    }
-                  ],
+                  "type": "string",
                   "description": "Unique identifier for the segment"
                 },
                 "start_time": {


### PR DESCRIPTION
…tity/extract

noticed that the structure of entities in on-demand extract slightly mismatched the one used in FileEntities from collections, should look like

```json
            "description": "The structured data extracted from the video based on prompt or schema",
            "type": "object",
            "properties": {
              "entities": {
                "type": "object",
                "description": "Entities extracted from the video level"
              },
```

so made change to make these consistent.

also segment ids are now canonically a string, so updating to avoid one of / which can add some unecessary funky code in some programing languages