### PR TITLE
doc: update doc with reference to not_applicable for segmentation job

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -3217,7 +3217,7 @@
                   "failed",
                   "not_applicable"
                 ],
-                "description": "Status of the segmentation job"
+                "description": "Status of the segmentation job. If a job has the status 'not_applicable' it means that we were unable to find any appropriate scenes for this video. This can be possible if you use the shot-detector strategy."
               },
               "file_id": {
                 "type": "string",


### PR DESCRIPTION
- updates the spec to account for the `not_applicable` status that is possible for segmentation jobs, when no scenes are able to be deteceted