### PR TITLE
Fixing casing of CloudGlue -> Cloudglue consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # cloudglue-api-spec
 
-Official OpenAPI specification for the CloudGlue API by Aviary Inc.
+Official OpenAPI specification for the Cloudglue API by Aviary Inc.
 
-This repo defines the structure, endpoints, and schemas of the CloudGlue API. For implementation guidance, SDKs, and examples, see our full documentation site.
+This repo defines the structure, endpoints, and schemas of the Cloudglue API. For implementation guidance, SDKs, and examples, see our full documentation site.
 
 ## 📖 Important Links
 
-- 📘 [CloudGlue API Documentation](https://docs.cloudglue.dev)
+- 📘 [Cloudglue API Documentation](https://docs.cloudglue.dev)
 - 📄 [Terms of Service](https://cloudglue.dev/terms)
 - 🔐 [Privacy Policy](https://cloudglue.dev/privacy)
 - 💸 [Pricing](https://cloudglue.dev/pricing)
@@ -14,7 +14,7 @@ This repo defines the structure, endpoints, and schemas of the CloudGlue API. Fo
 
 ---
 
-> 💡 **By using the CloudGlue API, you agree to the [Terms of Service](https://cloudglue.dev/terms) and acknowledge our [Privacy Policy](https://cloudglue.dev/privacy).**
+> 💡 **By using the Cloudglue API, you agree to the [Terms of Service](https://cloudglue.dev/terms) and acknowledge our [Privacy Policy](https://cloudglue.dev/privacy).**
 
 ## Contact
 


### PR DESCRIPTION
Fixing the casing of company name for consistency, preferring "Cloudglue", in readme