### PR TITLE
doc: add support for url when adding collection file to support upcoming s3 work

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -3133,10 +3133,13 @@
             "properties": {
               "file_id": {
                 "type": "string",
-                "description": "The ID of the file to add to the collection"
+                "description": "The ID of the file to add to the collection. If provided, url will be ignored"
+              },
+              "url": {
+                "type": "string",
+                "description": "The URL of the file to add to the collection. Either file_id or url must be provided."
               }
-            },
-            "required": ["file_id"]
+            }
           },
           {
             "$ref": "#/components/schemas/FileSegmentationConfig"


### PR DESCRIPTION
- Add support for either providing `url` or `file_id` when adding a file to collection. 
- This replacement will move to deprecate the specific `youtube` endpoint when adding videos to a collection