### PR TITLE
simplify params sent to chat completion api

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -4300,34 +4300,12 @@
               }
             }
           },
-          "force_search": {
-            "type": "boolean",
-            "description": "Whether to force the model to always perform a search when answering questions, even if it believes it knows the answer",
-            "default": false
-          },
-          "include_citations": {
-            "type": "boolean",
-            "description": "Whether to include citations to specific video segments",
-            "default": true
-          },
           "temperature": {
             "type": "number",
             "description": "Sampling temperature to use, between 0 and 2",
             "minimum": 0,
             "maximum": 2,
             "default": 0.7
-          },
-          "top_p": {
-            "type": "number",
-            "description": "An alternative to sampling with temperature, called nucleus sampling",
-            "minimum": 0,
-            "maximum": 1,
-            "default": 1.0
-          },
-          "max_tokens": {
-            "type": "integer",
-            "description": "The maximum number of tokens to generate in the chat completion",
-            "default": 1024
           }
         },
         "required": ["model", "messages", "collections"]


### PR DESCRIPTION
removing params from chat completion api (force_search, include_citations, top_p, max_tokens). moving forward force search logic is implicitly done and so is citations/always returned when available on API side, and top p / max tokens are now opaque to users, we'll default these values on backend side. these params will continue to be accepted for backwards compatibility but may not actually be respected / expected behavior enumerated in previous sentence.